### PR TITLE
onchange to change

### DIFF
--- a/jquery.jlabel.js
+++ b/jquery.jlabel.js
@@ -46,7 +46,7 @@
 				.focus(function() { focus($(this)); })
 				.blur(function() { blur($(this)); })
 				.keyup(function() { keyup($(this)); })
-				.onchange(function() { keyup($(this)); });
+				.change(function() { keyup($(this)); });
 		});
 
 		// Private: state object


### PR DESCRIPTION
jQuery doesn't have such a method as onchange. Changed to comply and
prevent console errors.

Tested using jQuery 1.10.1
