### PR TITLE
Declare $this variable

### DIFF
--- a/jquery.jlabel.js
+++ b/jquery.jlabel.js
@@ -38,7 +38,7 @@
 		var opts = $.extend({}, $.fn.jLabel.defaults, options);
 
 		return this.each(function() {
-			$this = $(this);
+			var $this = $(this);
 
 			states.push(new state($this));
 


### PR DESCRIPTION
Declare the `$this` variable. Otherwise minifying the script results in a warning:

```
jquery.jlabel-1.3.min.js:1: ERROR - variable $this is undeclared
```
